### PR TITLE
Allow logger name to be stored on ILogger objects

### DIFF
--- a/log4oe/Logger/AbstractLogger.cls
+++ b/log4oe/Logger/AbstractLogger.cls
@@ -26,6 +26,10 @@ CLASS log4oe.Logger.AbstractLogger IMPLEMENTS ILogger ABSTRACT:
     DEFINE PROTECTED PROPERTY Config AS ILoggerConfig NO-UNDO
     PROTECTED GET.
     PROTECTED SET.
+    
+    DEFINE PRIVATE PROPERTY LoggerName AS CHARACTER NO-UNDO
+    PRIVATE GET.
+    PRIVATE SET.
 
     METHOD PUBLIC VOID addLogAppender(INPUT poAppender AS ILogAppender):
 
@@ -50,6 +54,19 @@ CLASS log4oe.Logger.AbstractLogger IMPLEMENTS ILogger ABSTRACT:
 
     METHOD PUBLIC ILoggerConfig getLoggerConfig():
         RETURN Config.
+    END METHOD.
+    
+    METHOD PUBLIC VOID setLoggerName(INPUT pcLoggerName AS CHARACTER):
+        
+        IF pcLoggerName NE "" AND pcLoggerName NE ? THEN
+        DO:
+            ASSIGN LoggerName = TRIM(pcLoggerName).
+        END.
+        
+    END METHOD.
+    
+    METHOD PUBLIC CHARACTER getLoggerName():
+        RETURN LoggerName.
     END METHOD.
 
     METHOD PUBLIC VOID Log( INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER ):

--- a/log4oe/Logger/ILogger.cls
+++ b/log4oe/Logger/ILogger.cls
@@ -18,6 +18,10 @@ INTERFACE log4oe.Logger.ILogger:
     METHOD PUBLIC VOID setLoggerConfig(INPUT poLoggerConfig AS ILoggerConfig).
 
     METHOD PUBLIC ILoggerConfig getLoggerConfig().
+    
+    METHOD PUBLIC VOID setLoggerName(INPUT pcLoggerName AS CHARACTER).
+    
+    METHOD PUBLIC CHARACTER getLoggerName().
 
     METHOD PUBLIC VOID addLogAppender(INPUT poAppender AS ILogAppender).
 

--- a/log4oe/LoggerFactory.cls
+++ b/log4oe/LoggerFactory.cls
@@ -78,7 +78,10 @@ CLASS log4oe.LoggerFactory:
         /* Check that the logger object is a valid-object */
         IF NOT VALID-OBJECT(ttLogger.Logger) OR NOT ttLogger.Logger:GetClass():IsA("log4oe.Logger.ILogger") THEN
         DO:
+            /* Create and initialise logger */
             voLogger = DYNAMIC-NEW pcLoggerClass ().
+            voLogger:setLoggerName(pcLoggerName).
+            
             ASSIGN ttLogger.Logger = voLogger.
 
             /* Configure the logger */

--- a/log4oe/Tests/Logger/BasicLogger.cls
+++ b/log4oe/Tests/Logger/BasicLogger.cls
@@ -43,6 +43,45 @@ CLASS log4oe.Tests.Logger.BasicLogger:
         Assert:AreEqual(voLogger:getLoggerConfig(), voConfig).
 
     END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GetSetLoggerName():
+        
+        DEFINE VARIABLE vcName AS CHARACTER NO-UNDO INITIAL "TestLoggerName".
+        
+        voLogger:setLoggerName(vcName).
+        
+        Assert:AreEqual(voLogger:getLoggerName(), vcName).
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID SetLoggerName_NoOverwriteWhenBlankName():
+        
+        DEFINE VARIABLE vcName AS CHARACTER NO-UNDO INITIAL "TestLoggerName".
+        
+        // Set Initial value
+        voLogger:setLoggerName(vcName).
+        
+        // Should not overwrite if blank
+        voLogger:setLoggerName("").
+        Assert:AreEqual(voLogger:getLoggerName(), vcName).
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID SetLoggerName_NoOverwriteWhenNullName():
+        
+        DEFINE VARIABLE vcName AS CHARACTER NO-UNDO INITIAL "TestLoggerName".
+        
+        // Set Initial value
+        voLogger:setLoggerName(vcName).
+        
+        // Should not overwrite if null
+        voLogger:setLoggerName(?).
+        Assert:AreEqual(voLogger:getLoggerName(), vcName).
+        
+    END METHOD.
 
     @Test.
     METHOD PUBLIC VOID Log_ShouldLog():

--- a/log4oe/Tests/LoggerFactory.cls
+++ b/log4oe/Tests/LoggerFactory.cls
@@ -64,6 +64,14 @@ CLASS log4oe.tests.LoggerFactory:
     END METHOD.
 
     @Test.
+    METHOD PUBLIC VOID GetLogger_LoggerNameIsSet():
+        
+        Assert:IsNotNull(LoggerFactory:getLogger():getLoggerName(), "Logger name is null").
+        Assert:AreNotEqual(LoggerFactory:getLogger():getLoggerName(), "", "Logger name is blank").
+        
+    END METHOD.
+
+    @Test.
     METHOD PUBLIC VOID ResetFactory_ResetsConfig():
 
         DEFINE VARIABLE voConfig AS StubLoggerConfig NO-UNDO.

--- a/log4oe/Tests/Stubs/StubLogger.cls
+++ b/log4oe/Tests/Stubs/StubLogger.cls
@@ -24,6 +24,10 @@ CLASS log4oe.Tests.Stubs.StubLogger IMPLEMENTS ILogger:
     DEFINE PUBLIC PROPERTY AppenderObject AS ILogAppender NO-UNDO
     PUBLIC GET.
     PUBLIC SET.
+    
+    DEFINE PUBLIC PROPERTY LoggerName AS CHARACTER NO-UNDO
+    PUBLIC GET.
+    PUBLIC SET.
 
     METHOD PUBLIC VOID DEBUG( INPUT pcMessage AS CHARACTER ):
 
@@ -119,6 +123,14 @@ CLASS log4oe.Tests.Stubs.StubLogger IMPLEMENTS ILogger:
 
     METHOD PUBLIC VOID setLoggerConfig( INPUT poLoggerConfig AS ILoggerConfig ):
         ConfigObject = poLoggerConfig.
+    END METHOD.
+    
+    METHOD PUBLIC VOID setLoggerName(INPUT pcLoggerName AS CHARACTER):
+        LoggerName = pcLoggerName.
+    END METHOD.
+    
+    METHOD PUBLIC CHARACTER getLoggerName():
+        RETURN LoggerName.
     END METHOD.
 
 END CLASS.


### PR DESCRIPTION
This change allows the logger name to set or retrieve (set/get methods) on objects implementing the ILogger interface. It also implements the assignment of the name for ILogger objects created through the LoggerFactory.