### PR TITLE
Include individual message LogLevel value in logs

### DIFF
--- a/log4oe/LogAppender/AbstractLogAppender.cls
+++ b/log4oe/LogAppender/AbstractLogAppender.cls
@@ -38,24 +38,24 @@ CLASS log4oe.LogAppender.AbstractLogAppender IMPLEMENTS ILogAppender ABSTRACT:
         // Do nothing
     END METHOD.
 
-    METHOD PUBLIC VOID Log(INPUT pcMessage AS CHARACTER):
+    METHOD PUBLIC VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER):
         UNDO, THROW NEW Progress.Lang.AppError("Method not implemented in AbstractLogAppender").
     END METHOD.
 
-    METHOD PUBLIC VOID Log(INPUT peError AS Progress.Lang.Error):
+    METHOD PUBLIC VOID Log(INPUT piLogLevel AS INTEGER, INPUT peError AS Progress.Lang.Error):
 
         DEFINE VARIABLE viMessage AS INTEGER NO-UNDO.
 
-        THIS-OBJECT:Log('Error trapped with type ' + peError:GetClass():TypeName).
-        THIS-OBJECT:Log('Severity: ' + STRING(peError:Severity)).
+        THIS-OBJECT:Log(piLogLevel, 'Error trapped with type ' + peError:GetClass():TypeName).
+        THIS-OBJECT:Log(piLogLevel, 'Severity: ' + STRING(peError:Severity)).
 
         DO viMessage = 1 TO peError:NumMessages:
-            THIS-OBJECT:Log(peError:GetMessage(viMessage) + ' (' + STRING(peError:GetMessageNum(viMessage)) + ')').
+            THIS-OBJECT:Log(piLogLevel, peError:GetMessage(viMessage) + ' (' + STRING(peError:GetMessageNum(viMessage)) + ')').
         END.
 
         IF peError:CallStack NE ? THEN
         DO:
-            THIS-OBJECT:Log('Call Stack: ' + peError:CallStack).
+            THIS-OBJECT:Log(piLogLevel, 'Call Stack: ' + peError:CallStack).
         END.
 
     END METHOD.

--- a/log4oe/LogAppender/DSLogManagerAppender.cls
+++ b/log4oe/LogAppender/DSLogManagerAppender.cls
@@ -12,12 +12,15 @@
 USING Progress.Lang.*.
 USING log4oe.LogAppender.AbstractLogAppender.
 USING log4oe.LogAppender.ILogAppender.
+USING log4oe.LogLevel.
 
 BLOCK-LEVEL ON ERROR UNDO, THROW.
 
 CLASS log4oe.LogAppender.DSLogManagerAppender INHERITS AbstractLogAppender IMPLEMENTS ILogAppender:
 
     METHOD PUBLIC OVERRIDE VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER):
+        
+        ASSIGN pcMessage = "[" + LogLevel:getLogLevelFixedWidthDesc(piLogLevel) + "] " + pcMessage.
 
         IF Config:getSubsystemName() NE "" AND Config:getSubsystemName() NE ? THEN
         DO:

--- a/log4oe/LogAppender/DSLogManagerAppender.cls
+++ b/log4oe/LogAppender/DSLogManagerAppender.cls
@@ -17,7 +17,7 @@ BLOCK-LEVEL ON ERROR UNDO, THROW.
 
 CLASS log4oe.LogAppender.DSLogManagerAppender INHERITS AbstractLogAppender IMPLEMENTS ILogAppender:
 
-    METHOD PUBLIC OVERRIDE VOID Log(INPUT pcMessage AS CHARACTER):
+    METHOD PUBLIC OVERRIDE VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER):
 
         IF Config:getSubsystemName() NE "" AND Config:getSubsystemName() NE ? THEN
         DO:

--- a/log4oe/LogAppender/ILogAppender.cls
+++ b/log4oe/LogAppender/ILogAppender.cls
@@ -20,9 +20,9 @@ INTERFACE log4oe.LogAppender.ILogAppender:
 
     METHOD PUBLIC VOID Initialise().
 
-    METHOD PUBLIC VOID Log(INPUT pcMessage AS CHARACTER).
+    METHOD PUBLIC VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER).
 
-    METHOD PUBLIC VOID Log(INPUT peError AS Progress.Lang.Error).
+    METHOD PUBLIC VOID Log(INPUT piLogLevel AS INTEGER, INPUT peError AS Progress.Lang.Error).
 
 
 END INTERFACE.

--- a/log4oe/LogAppender/LogManagerAppender.cls
+++ b/log4oe/LogAppender/LogManagerAppender.cls
@@ -12,12 +12,15 @@
 USING Progress.Lang.*.
 USING log4oe.LogAppender.AbstractLogAppender.
 USING log4oe.LogAppender.ILogAppender.
+USING log4oe.LogLevel.
 
 BLOCK-LEVEL ON ERROR UNDO, THROW.
 
 CLASS log4oe.LogAppender.LogManagerAppender INHERITS AbstractLogAppender IMPLEMENTS ILogAppender:
 
     METHOD PUBLIC OVERRIDE VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER):
+        
+        ASSIGN pcMessage = "[" + LogLevel:getLogLevelFixedWidthDesc(piLogLevel) + "] " + pcMessage.
 
         IF Config:getSubsystemName() NE "" AND Config:getSubsystemName() NE ? THEN
         DO:

--- a/log4oe/LogAppender/LogManagerAppender.cls
+++ b/log4oe/LogAppender/LogManagerAppender.cls
@@ -17,7 +17,7 @@ BLOCK-LEVEL ON ERROR UNDO, THROW.
 
 CLASS log4oe.LogAppender.LogManagerAppender INHERITS AbstractLogAppender IMPLEMENTS ILogAppender:
 
-    METHOD PUBLIC OVERRIDE VOID Log(INPUT pcMessage AS CHARACTER):
+    METHOD PUBLIC OVERRIDE VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER):
 
         IF Config:getSubsystemName() NE "" AND Config:getSubsystemName() NE ? THEN
         DO:

--- a/log4oe/LogLevel.cls
+++ b/log4oe/LogLevel.cls
@@ -23,5 +23,67 @@ CLASS log4oe.LogLevel ABSTRACT:
     DEFINE PUBLIC STATIC PROPERTY ERROR AS INTEGER NO-UNDO INITIAL 2 GET.
     DEFINE PUBLIC STATIC PROPERTY FATAL AS INTEGER NO-UNDO INITIAL 1 GET.
     DEFINE PUBLIC STATIC PROPERTY OFF   AS INTEGER NO-UNDO INITIAL 0 GET.
+    
+    METHOD PUBLIC STATIC CHARACTER getLogLevelDesc(INPUT piLogLevel AS INTEGER):
+        
+        DEFINE VARIABLE vcDesc AS CHARACTER NO-UNDO.
+        
+        CASE piLogLevel:
+            
+            WHEN 0 THEN
+            DO:
+                ASSIGN vcDesc = "OFF".
+            END.
+            
+            WHEN 1 THEN
+            DO:
+                ASSIGN vcDesc = "FATAL".
+            END.
+            
+            WHEN 2 THEN
+            DO:
+                ASSIGN vcDesc = "ERROR".
+            END.
+            
+            WHEN 3 THEN
+            DO:
+                ASSIGN vcDesc = "WARN".
+            END.
+            
+            WHEN 4 THEN
+            DO:
+                ASSIGN vcDesc = "INFO".
+            END.
+            
+            WHEN 5 THEN
+            DO:
+                ASSIGN vcDesc = "DEBUG".
+            END.
+            
+            WHEN 6 THEN
+            DO:
+                ASSIGN vcDesc = "TRACE".
+            END.
+            
+            WHEN 7 THEN
+            DO:
+                ASSIGN vcDesc = "ALL".
+            END.
+            
+            OTHERWISE
+            DO:
+                ASSIGN vcDesc = "?????".
+            END.
+            
+        END CASE.
+        
+        RETURN vcDesc.
+        
+    END METHOD.
 
+    METHOD PUBLIC STATIC CHARACTER getLogLevelFixedWidthDesc(INPUT piLogLevel AS INTEGER):
+        
+        RETURN SUBSTRING(log4oe.LogLevel:getLogLevelDesc(piLogLevel) + "     ", 1, 5).
+        
+    END METHOD.
 END CLASS.

--- a/log4oe/Logger/AbstractLogger.cls
+++ b/log4oe/Logger/AbstractLogger.cls
@@ -84,7 +84,7 @@ CLASS log4oe.Logger.AbstractLogger IMPLEMENTS ILogger ABSTRACT:
 
                     IF VALID-OBJECT(voAppender) THEN
                     DO:
-                        voAppender:Log(pcMessage).
+                        voAppender:Log(piLogLevel, pcMessage).
                     END.
                 END.
                 ELSE
@@ -114,7 +114,7 @@ CLASS log4oe.Logger.AbstractLogger IMPLEMENTS ILogger ABSTRACT:
 
                     IF VALID-OBJECT(voAppender) THEN
                     DO:
-                        voAppender:Log(peError).
+                        voAppender:Log(piLogLevel, peError).
                     END.
                 END.
                 ELSE

--- a/log4oe/Tests/LogAppender/DSLogManagerAppender.cls
+++ b/log4oe/Tests/LogAppender/DSLogManagerAppender.cls
@@ -12,6 +12,7 @@ USING Progress.Lang.*.
 USING OEUnit.Assertion.*.
 USING log4oe.LogAppender.DSLogManagerAppender.
 USING log4oe.LoggerConfig.DSLogManagerConfig.
+USING log4oe.LogLevel.
 
 BLOCK-LEVEL ON ERROR UNDO, THROW.
 
@@ -79,7 +80,7 @@ CLASS log4oe.Tests.LogAppender.DSLogManagerAppender:
 
         voAppender:setLoggerConfig(INPUT voConfig).
 
-        voAppender:Log("Test Message").
+        voAppender:Log(LogLevel:INFO, "Test Message").
 
         FINALLY:
             DELETE OBJECT voConfig NO-ERROR.
@@ -101,7 +102,7 @@ CLASS log4oe.Tests.LogAppender.DSLogManagerAppender:
 
         voAppender:setLoggerConfig(INPUT voConfig).
 
-        voAppender:Log("Test Message").
+        voAppender:Log(LogLevel:INFO, "Test Message").
 
         FINALLY:
             DELETE OBJECT voConfig NO-ERROR.

--- a/log4oe/Tests/LogAppender/LogManagerAppender.cls
+++ b/log4oe/Tests/LogAppender/LogManagerAppender.cls
@@ -12,6 +12,7 @@ USING Progress.Lang.*.
 USING OEUnit.Assertion.*.
 USING log4oe.LogAppender.LogManagerAppender.
 USING log4oe.LoggerConfig.LogManagerConfig.
+USING log4oe.LogLevel.
 
 BLOCK-LEVEL ON ERROR UNDO, THROW.
 
@@ -97,7 +98,7 @@ CLASS log4oe.Tests.LogAppender.LogManagerAppender:
 
         voAppender:setLoggerConfig(INPUT voConfig).
 
-        voAppender:Log("Test Message").
+        voAppender:Log(LogLevel:WARN, "Test Message").
 
         FINALLY:
             DELETE OBJECT voConfig NO-ERROR.
@@ -119,7 +120,7 @@ CLASS log4oe.Tests.LogAppender.LogManagerAppender:
 
         voAppender:setLoggerConfig(INPUT voConfig).
 
-        voAppender:Log("Test Message").
+        voAppender:Log(LogLevel:WARN, "Test Message").
 
         FINALLY:
             DELETE OBJECT voConfig NO-ERROR.

--- a/log4oe/Tests/LogLevel.cls
+++ b/log4oe/Tests/LogLevel.cls
@@ -27,5 +27,66 @@ CLASS log4oe.Tests.LogLevel:
         Assert:AreEqual(LogLevel:FATAL, 1, "LogLevel:FATAL should be 1, but was not.").
         Assert:AreEqual(LogLevel:OFF,   0, "LogLevel:OFF should be 0, but was not.").
     END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID getLogLevelDesc_Valid():
+        
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:ALL),   "ALL").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:TRACE), "TRACE").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:DEBUG), "DEBUG").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:INFO),  "INFO").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:WARN),  "WARN").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:ERROR), "ERROR").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:FATAL), "FATAL").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(LogLevel:OFF),   "OFF").
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID getLogLevelDesc_Invalid():
+        
+        Assert:AreEqual(LogLevel:getLogLevelDesc(-1), "?????").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(8),  "?????").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(?),  "?????").
+
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID getLogLevelFixedWidthDesc_Valid():
+        
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:ALL),   "ALL  ").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:TRACE), "TRACE").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:DEBUG), "DEBUG").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:INFO),  "INFO ").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:WARN),  "WARN ").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:ERROR), "ERROR").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:FATAL), "FATAL").
+        Assert:AreEqual(LogLevel:getLogLevelFixedWidthDesc(LogLevel:OFF),   "OFF  ").
+        
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:ALL)),   5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:TRACE)), 5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:DEBUG)), 5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:INFO)),  5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:WARN)),  5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:ERROR)), 5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:FATAL)), 5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(LogLevel:OFF)),   5).
+        
+    END METHOD.
+    
+    
+    @Test.
+    METHOD PUBLIC VOID getLogLevelFixedWidthDesc_Invalid():
+        
+        Assert:AreEqual(LogLevel:getLogLevelDesc(-1), "?????").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(8),  "?????").
+        Assert:AreEqual(LogLevel:getLogLevelDesc(?),  "?????").
+        
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(-1)), 5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(8)),  5).
+        Assert:AreEqual(LENGTH(LogLevel:getLogLevelFixedWidthDesc(?)),  5).
+
+    END METHOD.
+    
 
 END CLASS.

--- a/log4oe/Tests/Logger.cls
+++ b/log4oe/Tests/Logger.cls
@@ -52,6 +52,7 @@ CLASS log4oe.tests.Logger:
 
         Logger:Log(LogLevel:WARN, "Message").
         Assert:AreEqual(voConfig:LogAppender:LoggedMessage, "Message").
+        Assert:AreEqual(voConfig:LogAppender:LoggedLevel, LogLevel:WARN).
 
     END METHOD.
 
@@ -72,6 +73,7 @@ CLASS log4oe.tests.Logger:
 
         Logger:Log(LogLevel:WARN, voError).
         Assert:AreEqual(voConfig:LogAppender:LoggedError, voError).
+        Assert:AreEqual(voConfig:LogAppender:LoggedLevel, LogLevel:WARN).
 
     END METHOD.
 

--- a/log4oe/Tests/Logger/BasicLogger.cls
+++ b/log4oe/Tests/Logger/BasicLogger.cls
@@ -100,6 +100,7 @@ CLASS log4oe.Tests.Logger.BasicLogger:
         voLogger:Log(INPUT LogLevel:INFO, "Message").
 
         Assert:AreEqual(voAppender:LoggedMessage, "Message").
+        Assert:AreEqual(voAppender:LoggedLevel, LogLevel:INFO).
 
         FINALLY:
             DELETE OBJECT voConfig NO-ERROR.
@@ -152,6 +153,7 @@ CLASS log4oe.Tests.Logger.BasicLogger:
         voLogger:Log(INPUT LogLevel:INFO, INPUT voError).
 
         Assert:AreEqual(voAppender:LoggedError, voError).
+        Assert:AreEqual(voAppender:LoggedLevel, LogLevel:INFO).
 
         FINALLY:
             DELETE OBJECT voConfig   NO-ERROR.

--- a/log4oe/Tests/Stubs/StubLogAppender.cls
+++ b/log4oe/Tests/Stubs/StubLogAppender.cls
@@ -23,6 +23,10 @@ CLASS log4oe.Tests.Stubs.StubLogAppender IMPLEMENTS ILogAppender:
     DEFINE PUBLIC PROPERTY Initialised AS LOGICAL NO-UNDO INITIAL FALSE
     PUBLIC GET.
     PRIVATE SET.
+    
+    DEFINE PUBLIC PROPERTY LoggedLevel AS INTEGER NO-UNDO
+    PUBLIC GET.
+    PRIVATE SET.
 
     DEFINE PUBLIC PROPERTY LoggedError AS Progress.Lang.Error NO-UNDO
     PUBLIC GET.
@@ -36,12 +40,14 @@ CLASS log4oe.Tests.Stubs.StubLogAppender IMPLEMENTS ILogAppender:
         ASSIGN Initialised = TRUE.
     END METHOD.
 
-    METHOD PUBLIC VOID Log(INPUT pcMessage AS CHARACTER):
-        ASSIGN LoggedMessage = pcMessage.
+    METHOD PUBLIC VOID Log(INPUT piLogLevel AS INTEGER, INPUT pcMessage AS CHARACTER):
+        ASSIGN LoggedMessage = pcMessage
+               LoggedLevel   = piLogLevel.
     END METHOD.
 
-    METHOD PUBLIC VOID Log(INPUT peError AS Progress.Lang.Error):
-        ASSIGN LoggedError = peError.
+    METHOD PUBLIC VOID Log(INPUT piLogLevel AS INTEGER, INPUT peError AS Progress.Lang.Error):
+        ASSIGN LoggedError = peError
+               LoggedLevel = piLogLevel.
     END METHOD.
 
     METHOD PUBLIC ILoggerConfig getLoggerConfig():


### PR DESCRIPTION
When outputting a message to a log, include the LogLevel value for that individual message